### PR TITLE
Modified how $(FSharpTargetsPath) is set so I can build the project

### DIFF
--- a/FeldSpar.ContinuousIntegration/FeldSpar.ContinuousIntegration.fsproj
+++ b/FeldSpar.ContinuousIntegration/FeldSpar.ContinuousIntegration.fsproj
@@ -46,16 +46,21 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+    <When Condition="'$(VisualStudioVersion)' != '11.0' and Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>

--- a/FeldSparFramework/FeldSpar.Framework.fsproj
+++ b/FeldSparFramework/FeldSpar.Framework.fsproj
@@ -39,16 +39,21 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+    <When Condition="'$(VisualStudioVersion)' != '11.0' and Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+      <PropertyGroup>
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
     </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>


### PR DESCRIPTION
I cloned FeldSpar and then ran build.bat
It failed with

```
build.bat fails with
       "C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj" (Build target) (1) ->
         C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj(53,3): error MSB4102: The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.
```

When I open the sln file in Visual Studio 2013 the projects FeldSpar.Framework and FeldSpar.ContinuousIntegration can't be opened.

```
C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj : error  : The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.  C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj

C:\code\github\FeldSpar\FeldSpar.ContinuousIntegration\FeldSpar.ContinuousIntegration.fsproj : error  : The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.  C:\code\github\FeldSpar\FeldSpar.ContinuousIntegration\FeldSpar.ContinuousIntegration.fsproj

C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj : error  : The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.  C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj

C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj : error  : The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.  C:\code\github\FeldSpar\FeldSparFramework\FeldSpar.Framework.fsproj

C:\code\github\FeldSpar\FeldSpar.ContinuousIntegration\FeldSpar.ContinuousIntegration.fsproj : error  : The value "" of the "Project" attribute in element <Import> is invalid. Parameter "path" cannot have zero length.  C:\code\github\FeldSpar\FeldSpar.ContinuousIntegration\FeldSpar.ContinuousIntegration.fsproj
```

I have no problem building for example FAKE so I modified how the $(FSharpTargetsPath) is set in the failing fsproj files.

And after that I can open the sln and compile the code.
Running build.cmd still fails but now it's 14 tests that fails. I don't think this change caused that :-)
